### PR TITLE
Fix font clipping when "Minimum font size" is adjusted in Chrome

### DIFF
--- a/src/components/Common/AssetCard/AssetCardMain/AssetCardMain.scss
+++ b/src/components/Common/AssetCard/AssetCardMain/AssetCardMain.scss
@@ -48,7 +48,6 @@
     justify-content: flex-end;
     overflow: hidden;
     height: 40px;
-    padding-bottom: 2px;
 }
 .AssetCardMain__header {
     display: flex;
@@ -86,7 +85,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     opacity: 0.6;
-    height: 8px;
     line-height: 1;
     text-align: left;
 }


### PR DESCRIPTION
This PR fixes asset issuer small font in Chrome when "Minimum font size" is more than 10 in chrome://settings/fonts.

Chrome 80.0.3987.149 (Official Build) (64-bit)

<img width="1005" alt="Screen Shot 2020-03-23 at 19 36 44" src="https://user-images.githubusercontent.com/61785248/77418849-8a5dfb80-6dd8-11ea-894c-748786cb12c1.png">

![image (1)](https://user-images.githubusercontent.com/61785248/77419301-3c95c300-6dd9-11ea-95a4-cdda813b39cd.png)

There is no visual changes for default preferences, but scaled-up font looks good.

<img width="1369" alt="Screen Shot 2020-03-24 at 14 23 11" src="https://user-images.githubusercontent.com/61785248/77420479-2852c580-6ddb-11ea-9958-5dc158e5adba.png">

